### PR TITLE
Replace unpinned actions with pinned action

### DIFF
--- a/.github/workflows/build-binary-signed-ghat-malicious.yml
+++ b/.github/workflows/build-binary-signed-ghat-malicious.yml
@@ -1,8 +1,6 @@
 name: binary-signed-ghat-malicious
-
 on:
   workflow_dispatch:
-
 jobs:
   build:
     permissions:
@@ -12,28 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: The malicious step
         run: |
           echo "// This is a malicious update" >> main.go
-
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version: '1.21'
-
       - name: Run Go build
         run: |
           go build -v -o demo-go-binary ./...
-
       - name: Sign artifact
-        uses: github-early-access/generate-build-provenance@main
+        uses: github-early-access/generate-build-provenance@28796e954ac71d8e3b17c262cd644dcd1001cb6a # main
         with:
           subject-path: '${{ github.workspace }}/demo-go-binary'
-
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: demo-go-binary
           path: demo-go-binary

--- a/.github/workflows/build-binary-signed-ghat.yml
+++ b/.github/workflows/build-binary-signed-ghat.yml
@@ -1,8 +1,6 @@
 name: binary-signed-ghat
-
 on:
   workflow_dispatch:
-
 jobs:
   build:
     permissions:
@@ -12,24 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version: '1.21'
-
       - name: Run Go build
         run: |
           go build -v -o demo-go-binary ./...
-
       - name: Sign artifact
-        uses: github-early-access/generate-build-provenance@main
+        uses: github-early-access/generate-build-provenance@28796e954ac71d8e3b17c262cd644dcd1001cb6a # main
         with:
           subject-path: '${{ github.workspace }}/demo-go-binary'
-
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: demo-go-binary
           path: demo-go-binary

--- a/.github/workflows/build-binary-unsigned.yml
+++ b/.github/workflows/build-binary-unsigned.yml
@@ -1,8 +1,6 @@
 name: binary-unsigned
-
 on:
   workflow_dispatch:
-
 jobs:
   build:
     permissions:
@@ -12,24 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version: '1.21'
-
       - name: Run Go build
         run: |
           go build -v -o demo-go-binary ./...
-
-#      - name: Sign artifact
-#        uses: github-early-access/generate-build-provenance@main
-#        with:
-#          subject-path: '${{ github.workspace }}/demo-go-binary'
-
+        #      - name: Sign artifact
+        #        uses: github-early-access/generate-build-provenance@main
+        #        with:
+        #          subject-path: '${{ github.workspace }}/demo-go-binary'
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: demo-go-binary
           path: demo-go-binary

--- a/.github/workflows/build-image-signed-ghat-malicious.yml
+++ b/.github/workflows/build-image-signed-ghat-malicious.yml
@@ -1,7 +1,6 @@
 name: image-signed-ghat(latest)-malicious
 on:
   workflow_dispatch:
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -9,22 +8,18 @@ jobs:
       id-token: write
       packages: write
       contents: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-
       - name: The malicious step
         run: |
           echo "// This is a malicious update" >> main.go
-
       - name: Log into ghcr.io
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and push image
         id: push-step
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
@@ -32,9 +27,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
           context: .
-
       - name: Attest image
-        uses: github-early-access/generate-build-provenance@main
+        uses: github-early-access/generate-build-provenance@28796e954ac71d8e3b17c262cd644dcd1001cb6a # main
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}

--- a/.github/workflows/build-image-signed-ghat-private.yml
+++ b/.github/workflows/build-image-signed-ghat-private.yml
@@ -1,7 +1,6 @@
 name: image-signed-ghat(latest)-private
 on:
   workflow_dispatch:
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -9,18 +8,15 @@ jobs:
       id-token: write
       packages: write
       contents: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-
       - name: Log into ghcr.io
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and push image
         id: push-step
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
@@ -28,9 +24,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
           context: .
-
       - name: Attest image
-        uses: github-early-access/generate-build-provenance@main
+        uses: github-early-access/generate-build-provenance@28796e954ac71d8e3b17c262cd644dcd1001cb6a # main
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}

--- a/.github/workflows/build-image-signed-ghat.yml
+++ b/.github/workflows/build-image-signed-ghat.yml
@@ -1,7 +1,6 @@
 name: image-signed-ghat(latest)
 on:
   workflow_dispatch:
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -9,18 +8,15 @@ jobs:
       id-token: write
       packages: write
       contents: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
-
       - name: Log into ghcr.io
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and push image
         id: push-step
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
@@ -28,9 +24,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}:latest
           context: .
-
       - name: Attest image
-        uses: github-early-access/generate-build-provenance@main
+        uses: github-early-access/generate-build-provenance@28796e954ac71d8e3b17c262cd644dcd1001cb6a # main
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push-step.outputs.digest }}


### PR DESCRIPTION
<!-- minder: pr-remediation-body: { "ContentSha": "16ff3aa6684082d37505872e6f3df442f2c1b035" } -->

This is a Minder automated pull request.

This pull request replaces references to actions by tag to references to actions by SHA.

Verifies that any actions use pinned tags
Pinning an action to a full length commit SHA is currently the only way to use
an action as an immutable release. Pinning to a particular SHA helps mitigate
the risk of a bad actor adding a backdoor to the action's repository, as they
would need to generate a SHA-1 collision for a valid Git object payload.
When selecting a SHA, you should verify it is from the action's repository
and not a repository fork.

For more information, see
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
